### PR TITLE
Remove breaking jQuery selector

### DIFF
--- a/app/assets/javascripts/turbolinks-form-core.js
+++ b/app/assets/javascripts/turbolinks-form-core.js
@@ -30,7 +30,7 @@ TurbolinksForm.on = function(eventHandlerOwner, event, delegateSelector, handler
     delegateSelector = undefined;
   }
 
-  $(eventHandlerOwner).on(event, function(e) {
+  eventHandlerOwner.addEventListener(event, function(e) {
     if (delegateSelector) {
       // goes up the dom tree searching for the delegate
       var currentTarget = e.target;


### PR DESCRIPTION
Removes a reference to jQuery function that doesn't exist in environments that do not run jQuery.

I've only tested this in my environment, which isn't using jQuery, so def test this to make sure it works for environments that are using jQuery before this is merged.